### PR TITLE
fix(sync): prefer iCloud Keychain over local when credential sync is enabled

### DIFF
--- a/App/AerioApp.swift
+++ b/App/AerioApp.swift
@@ -1246,9 +1246,9 @@ struct RootView: View {
     ///     already exists for the same key. So re-running can't
     ///     corrupt or downgrade an already-migrated credential.
     ///   • Local Keychain items remain in place — we don't delete
-    ///     them. `effectivePassword`/`effectiveApiKey`'s read order
-    ///     (local → iCloud → SwiftData) makes the local copy a
-    ///     valid fallback if the user later disables iCloud Sync.
+    ///     them. `effectivePassword`/`effectiveApiKey` prefer the
+    ///     iCloud copy while credential sync is enabled, but fall
+    ///     back to the local copy when sync is off.
     ///
     /// v1.6.12 update: KVS plaintext is no longer written by this
     ///   version. `SyncManager.serialize` stopped emitting
@@ -1613,9 +1613,9 @@ struct RootView: View {
         // through the KVS plaintext path. The local-only write stays
         // for the case where the user later disables iCloud Sync —
         // they still need a copy of their credentials on this device.
-        // `effectivePassword` / `effectiveApiKey` already prefer local,
-        // then iCloud, then SwiftData, so the dual write is invisible
-        // to readers. v1.6.7 devices keep working because we still
+        // `effectivePassword` / `effectiveApiKey` already resolve the
+        // right copy for the current sync mode, so the dual write is
+        // invisible to readers. v1.6.7 devices keep working because we still
         // include plaintext in the KVS payload (see
         // `SyncManager.serialize`); the KVS plaintext gets phased out
         // in v1.7.x once the v1.6.7 install base has rolled forward.

--- a/Models/Models.swift
+++ b/Models/Models.swift
@@ -206,22 +206,33 @@ final class ServerConnection {
 
     // MARK: - Keychain-backed credentials
 
-    /// The effective password: reads from local Keychain first, then iCloud
-    /// Keychain (synchronizable), then falls back to the SwiftData field.
-    var effectivePassword: String {
-        let key = "password_\(id.uuidString)"
+    /// Resolves a credential from Keychain. When iCloud credential sync is
+    /// enabled, prefer the synchronizable copy so remote updates win over a
+    /// stale local-only cache. When sync is off, keep the historical local-
+    /// first order so this device still works offline / local-only.
+    private func resolvedCredential(for key: String, fallback: String) -> String {
+        if UserDefaults.standard.bool(forKey: "iCloudSyncEnabled") && SyncCategory.credentials.isEnabled {
+            return KeychainHelper.load(key: key, synchronizable: true)
+                ?? KeychainHelper.load(key: key)
+                ?? fallback
+        }
         return KeychainHelper.load(key: key)
             ?? KeychainHelper.load(key: key, synchronizable: true)
-            ?? password
+            ?? fallback
     }
 
-    /// The effective API key: reads from local Keychain first, then iCloud
-    /// Keychain (synchronizable), then falls back to the SwiftData field.
+    /// The effective password. When credential sync is enabled, prefers the
+    /// iCloud Keychain copy so cross-device updates beat stale local items.
+    var effectivePassword: String {
+        let key = "password_\(id.uuidString)"
+        return resolvedCredential(for: key, fallback: password)
+    }
+
+    /// The effective API key. When credential sync is enabled, prefers the
+    /// iCloud Keychain copy so cross-device updates beat stale local items.
     var effectiveApiKey: String {
         let key = "apiKey_\(id.uuidString)"
-        return KeychainHelper.load(key: key)
-            ?? KeychainHelper.load(key: key, synchronizable: true)
-            ?? apiKey
+        return resolvedCredential(for: key, fallback: apiKey)
     }
 
     /// Persists `password` and `apiKey` to the Keychain, then clears the plaintext

--- a/Models/Models.swift
+++ b/Models/Models.swift
@@ -208,8 +208,9 @@ final class ServerConnection {
 
     /// Resolves a credential from Keychain. When iCloud credential sync is
     /// enabled, prefer the synchronizable copy so remote updates win over a
-    /// stale local-only cache. When sync is off, keep the historical local-
-    /// first order so this device still works offline / local-only.
+    /// stale local-only cache. Otherwise — including when iCloud Sync is
+    /// off or the Credentials sync category is disabled — keep the historical
+    /// local-first order so this device still works offline / local-only.
     private func resolvedCredential(for key: String, fallback: String) -> String {
         if UserDefaults.standard.bool(forKey: "iCloudSyncEnabled") && SyncCategory.credentials.isEnabled {
             return KeychainHelper.load(key: key, synchronizable: true)

--- a/Shared/SyncManager.swift
+++ b/Shared/SyncManager.swift
@@ -764,8 +764,11 @@ final class SyncManager: ObservableObject {
             server.saveCredentialsToKeychain()
             return
         }
-        let pw  = server.effectivePassword.isEmpty ? server.password : server.effectivePassword
-        let key = server.effectiveApiKey.isEmpty ? server.apiKey : server.effectiveApiKey
+        // Prefer in-memory edits over cached keychain copies so a user can
+        // rotate credentials on this device even when an older value is still
+        // present locally or in iCloud Keychain.
+        let pw  = server.password.isEmpty ? server.effectivePassword : server.password
+        let key = server.apiKey.isEmpty ? server.effectiveApiKey : server.apiKey
         let id  = server.id.uuidString
 
         if !pw.isEmpty {


### PR DESCRIPTION
When Dispatcharr API mode was used with iCloud Sync, a stale local Keychain entry could shadow a freshly synced iCloud Keychain value, causing the API key to appear valid on the originating device but broken on every other device.