### PR TITLE
Fix EPG refresh correctness, stale guide data, and cross-playlist tint bleed

### DIFF
--- a/Features/Home/HomeView.swift
+++ b/Features/Home/HomeView.swift
@@ -794,26 +794,26 @@ final class ChannelStore: ObservableObject {
         }
     }
 
-    /// UserDefaults key for the cached channel→category map. Cached
-    /// on every successful XMLTV categories pass so subsequent app
-    /// launches can render the "Tint Channel Cards" gradient
-    /// immediately, before the (multi-second) XMLTV fetch+parse has
-    /// even started. Without this cache, users saw channel cards
-    /// pop in tintless on every launch and the color faded in
-    /// ~5–10 seconds later — which is what the #22 feedback
-    /// ("gradients took way too long to load") called out.
-    private static let cachedCategoriesKey = "cachedChannelCategories.v1"
+    /// UserDefaults key prefix for the cached channel→category map.
+    /// Scoped per server so switching playlists can't briefly reuse
+    /// tint data learned from a different server that happens to
+    /// share the same channel ids.
+    private static let cachedCategoriesKeyPrefix = "cachedChannelCategories.v1"
 
     /// Snapshot of the last-known channel→category map. Written by
     /// `applyXMLTVCategories` after a fresh pass lands, read by
-    /// `primeCategoriesFromCache()` on the next cold load so the
-    /// tint renders on the first frame instead of 5–10 s later.
-    private static func loadCachedCategories() -> [String: String] {
-        UserDefaults.standard.dictionary(forKey: cachedCategoriesKey) as? [String: String] ?? [:]
+    /// `primeCategoriesFromCache(serverID:)` on the next cold load so
+    /// the tint renders on the first frame instead of 5–10 s later.
+    private static func cachedCategoriesKey(for serverID: String) -> String {
+        "\(cachedCategoriesKeyPrefix).\(serverID)"
     }
 
-    private static func saveCachedCategories(_ map: [String: String]) {
-        UserDefaults.standard.set(map, forKey: cachedCategoriesKey)
+    private static func loadCachedCategories(for serverID: String) -> [String: String] {
+        UserDefaults.standard.dictionary(forKey: cachedCategoriesKey(for: serverID)) as? [String: String] ?? [:]
+    }
+
+    private static func saveCachedCategories(_ map: [String: String], for serverID: String) {
+        UserDefaults.standard.set(map, forKey: cachedCategoriesKey(for: serverID))
     }
 
     /// Apply whatever category data we have cached from the last
@@ -822,10 +822,10 @@ final class ChannelStore: ObservableObject {
     /// overwrites with current data — this just means the user
     /// doesn't stare at an uncolored card while the XMLTV parse
     /// churns. Call from the channel-load success path.
-    func primeCategoriesFromCache() {
-        let cached = Self.loadCachedCategories()
+    func primeCategoriesFromCache(serverID: String) {
+        let cached = Self.loadCachedCategories(for: serverID)
         guard !cached.isEmpty else { return }
-        applyXMLTVCategories(cached)
+        applyXMLTVCategories(cached, serverID: serverID)
     }
 
     /// Called by `GuideStore` when an XMLTV parse surfaces category
@@ -891,30 +891,35 @@ final class ChannelStore: ObservableObject {
         }
     }
 
-    func applyXMLTVCategories(_ categoriesByChannelID: [String: String]) {
+    func applyXMLTVCategories(_ categoriesByChannelID: [String: String], serverID: String) {
         guard !categoriesByChannelID.isEmpty else { return }
-        var changed = false
-        var updated = channels
-        for i in updated.indices {
-            if let cat = categoriesByChannelID[updated[i].id],
-               updated[i].currentProgramCategory != cat {
-                updated[i].currentProgramCategory = cat
-                changed = true
+        let shouldApplyToCurrentChannels =
+            currentChannelServerID?.uuidString == serverID || activeServer?.id.uuidString == serverID
+
+        if shouldApplyToCurrentChannels {
+            var changed = false
+            var updated = channels
+            for i in updated.indices {
+                if let cat = categoriesByChannelID[updated[i].id],
+                   updated[i].currentProgramCategory != cat {
+                    updated[i].currentProgramCategory = cat
+                    changed = true
+                }
             }
-        }
-        if changed {
-            channels = updated
+            if changed {
+                channels = updated
+            }
         }
         // Persist so the next app launch can prime the tint from
         // cache on the first frame. Merging into the existing cache
         // rather than replacing means a partial XMLTV pass (e.g.,
         // parser errored halfway) doesn't wipe previously-known
         // categories for channels it didn't cover.
-        var merged = Self.loadCachedCategories()
+        var merged = Self.loadCachedCategories(for: serverID)
         for (id, cat) in categoriesByChannelID {
             merged[id] = cat
         }
-        Self.saveCachedCategories(merged)
+        Self.saveCachedCategories(merged, for: serverID)
     }
 
     /// Returns the URL AerioTV should pull XMLTV from for a
@@ -966,13 +971,15 @@ final class ChannelStore: ObservableObject {
         // the call site sync-clean.
         let snapshot = channels
         guard let activeServer = activeServer else { return }
+        let categoryServerID = activeServer.id.uuidString
 
         await GuideStore.shared.fetchXMLTVFromURL(
             url: url,
             channels: snapshot,
             windowStart: windowStart,
             windowEnd: windowEnd,
-            headers: headers
+            headers: headers,
+            categoryServerID: categoryServerID
         )
         // Propagate into EPGCache so List-view `fetchUpcoming`
         // (which reads EPGCache) picks up category-enriched
@@ -1080,7 +1087,7 @@ final class ChannelStore: ObservableObject {
                 // instead of fading in 5–10 seconds later when the
                 // live XMLTV parse wraps. The fresh XMLTV pass in
                 // `loadAllEPG` still overwrites with current data.
-                primeCategoriesFromCache()
+                primeCategoriesFromCache(serverID: serverID.uuidString)
                 TopShelfDataManager.syncTopChannels(channels: items)
                 DebugLogger.shared.logChannelLoad(
                     serverType: type.rawValue,
@@ -1254,6 +1261,7 @@ final class ChannelStore: ObservableObject {
         // a SwiftData model; reading a property after an `await`
         // suspension risks a thread-context violation.
         let dispatcharrXMLTVOverride = server.dispatcharrXMLTVURL
+        let categoryServerID = server.id.uuidString
         // v1.6.20: snapshot the auto-detected auth header mode + UA
         // so the off-main-thread API constructor uses the per-server
         // shape instead of the default `.xapikey`.
@@ -1535,7 +1543,7 @@ final class ChannelStore: ObservableObject {
                     }
                     debugLog("📺 Category enrichment: \(byChan.count)/\(currentByChannelID.count) channels got categories")
                     await MainActor.run {
-                        ChannelStore.shared.applyXMLTVCategories(byChan)
+                        ChannelStore.shared.applyXMLTVCategories(byChan, serverID: categoryServerID)
                     }
 
                     // v1.7: propagate the channel's category to ALL

--- a/Features/Home/HomeView.swift
+++ b/Features/Home/HomeView.swift
@@ -769,12 +769,20 @@ final class ChannelStore: ObservableObject {
 
     /// Called by pull-to-refresh — always re-fetches channels AND EPG.
     /// This is async so the pull-to-refresh spinner stays visible until done.
+    /// Callers that need the refreshed guide persisted to SwiftData should
+    /// follow this with `GuideStore.shared.saveToCache(...)`.
     func forceRefresh(servers: [ServerConnection]) async {
         guard let server = servers.first(where: { $0.isActive }) ?? servers.first else { return }
         activeServer = server
+        currentChannelServerID = server.id
         loadTask?.cancel()
         epgEnrichTask?.cancel()
         await load(server: server)
+
+        guard !Task.isCancelled, !channels.isEmpty else { return }
+
+        await GuideStore.shared.fetchUpcoming(channels: channels, servers: servers)
+        await GuideStore.shared.seedEPGCache(channels: channels, server: server)
     }
 
     /// UserDefaults key for the cached channel→category map. Cached

--- a/Features/Home/HomeView.swift
+++ b/Features/Home/HomeView.swift
@@ -769,9 +769,8 @@ final class ChannelStore: ObservableObject {
 
     /// Called by pull-to-refresh — always re-fetches channels AND EPG.
     /// This is async so the pull-to-refresh spinner stays visible until done.
-    /// Callers that need the refreshed guide persisted to SwiftData should
-    /// follow this with `GuideStore.shared.saveToCache(...)`.
-    func forceRefresh(servers: [ServerConnection]) async {
+    /// Pass `modelContext` to persist the rebuilt guide back to SwiftData.
+    func forceRefresh(servers: [ServerConnection], modelContext: ModelContext? = nil) async {
         guard let server = servers.first(where: { $0.isActive }) ?? servers.first else { return }
         activeServer = server
         currentChannelServerID = server.id
@@ -781,8 +780,18 @@ final class ChannelStore: ObservableObject {
 
         guard !Task.isCancelled, !channels.isEmpty else { return }
 
-        await GuideStore.shared.fetchUpcoming(channels: channels, servers: servers)
+        isEPGLoading = true
+        let didRefreshGuide = await GuideStore.shared.fetchUpcoming(
+            channels: channels,
+            servers: servers,
+            replaceExisting: true
+        )
+        isEPGLoading = false
+
         await GuideStore.shared.seedEPGCache(channels: channels, server: server)
+        if didRefreshGuide, let modelContext {
+            GuideStore.shared.saveToCache(modelContext: modelContext, serverID: server.id.uuidString)
+        }
     }
 
     /// UserDefaults key for the cached channel→category map. Cached
@@ -5223,4 +5232,3 @@ struct MiniPlayerBar: View {
     }
 }
 #endif
-

--- a/Features/LiveTV/ChannelListView.swift
+++ b/Features/LiveTV/ChannelListView.swift
@@ -28,6 +28,7 @@ struct ChannelListView: View {
     @EnvironmentObject private var nowPlaying: NowPlayingManager
     @EnvironmentObject private var favoritesStore: FavoritesStore
     @EnvironmentObject private var channelStore: ChannelStore
+    @Environment(\.modelContext) private var modelContext
     @Environment(\.horizontalSizeClass) private var sizeClass
 
     @Query private var servers: [ServerConnection]
@@ -478,7 +479,7 @@ struct ChannelListView: View {
                 icon: "tv",
                 title: "No Channels",
                 message: "No channels found on the active server.",
-                action: { Task { await channelStore.forceRefresh(servers: servers) } },
+                action: { Task { await channelStore.forceRefresh(servers: servers, modelContext: modelContext) } },
                 actionTitle: "Refresh"
             )
         } else if showGuideView {
@@ -735,7 +736,7 @@ struct ChannelListView: View {
             }
             .refreshable {
                 await EPGCache.shared.invalidateAll()
-                await channelStore.forceRefresh(servers: servers)
+                await channelStore.forceRefresh(servers: servers, modelContext: modelContext)
             }
             // iPhone-only: collapse the chrome (filter pills) when the
             // list scrolls past 80pt; expand again near the top (< 20pt).
@@ -950,7 +951,7 @@ struct ChannelListView: View {
                 .foregroundColor(.textSecondary)
                 .multilineTextAlignment(.center)
             PrimaryButton("Try Again") {
-                Task { await channelStore.forceRefresh(servers: servers) }
+                Task { await channelStore.forceRefresh(servers: servers, modelContext: modelContext) }
             }
             .frame(maxWidth: 200)
         }

--- a/Features/LiveTV/EPGGuideView.swift
+++ b/Features/LiveTV/EPGGuideView.swift
@@ -114,15 +114,41 @@ final class GuideStore: ObservableObject {
     /// on the same @MainActor won't race.
     private var lastSeedEPGCacheSignature: String? = nil
 
-    private func beginBatch() {
+    private func beginBatch(basePrograms: [String: [GuideProgram]]? = nil) {
         _isBatching = true
-        _pendingPrograms = programs
+        _pendingPrograms = basePrograms ?? programs
     }
 
     private func endBatch() {
         _isBatching = false
         programs = _pendingPrograms
         _pendingPrograms = [:]
+    }
+
+    private func cancelBatch() {
+        _isBatching = false
+        _pendingPrograms = [:]
+    }
+
+    private func replacingWindowBase(
+        for channels: [ChannelDisplayItem],
+        windowStart: Date,
+        windowEnd: Date
+    ) -> [String: [GuideProgram]] {
+        let channelIDs = Set(channels.map(\.id))
+        guard !channelIDs.isEmpty else { return programs }
+
+        var result = programs
+        for channelID in channelIDs {
+            guard var existing = result[channelID] else { continue }
+            existing.removeAll { $0.end > windowStart && $0.start < windowEnd }
+            if existing.isEmpty {
+                result.removeValue(forKey: channelID)
+            } else {
+                result[channelID] = existing
+            }
+        }
+        return result
     }
 
     /// Phase 0 — load persisted EPG from SwiftData. Returns true if cache was fresh enough.
@@ -471,10 +497,15 @@ final class GuideStore: ObservableObject {
 
     /// Phase 2 — async: fetch upcoming programs to fill in the timeline beyond "now playing."
     /// Loads an initial batch quickly, then backfills remaining channels at lower priority.
-    func fetchUpcoming(channels: [ChannelDisplayItem], servers: [ServerConnection]) async {
+    @discardableResult
+    func fetchUpcoming(
+        channels: [ChannelDisplayItem],
+        servers: [ServerConnection],
+        replaceExisting: Bool = false
+    ) async -> Bool {
         guard !isLoading else {
             debugLog("📺 GuideStore.fetchUpcoming: already loading, skipping")
-            return
+            return false
         }
         isLoading = true
         // Previously the only `isLoading = false` assignment was on
@@ -497,24 +528,35 @@ final class GuideStore: ObservableObject {
 
         guard let server = servers.first(where: { $0.isActive }) ?? servers.first else {
             debugLog("📺 GuideStore.fetchUpcoming: no server found")
-            return  // `defer` above resets isLoading
+            return false  // `defer` above resets isLoading
         }
         debugLog("📺 GuideStore.fetchUpcoming: server=\(server.name), type=\(server.type), channels=\(channels.count)")
 
+        let didRefresh: Bool
         switch server.type {
         case .dispatcharrAPI:
             // Dispatcharr: bulk fetch ALL programs at once (no batching needed).
             // getCurrentPrograms + getBulkUpcomingPrograms handles everything.
-            await fetchDispatcharr(server: server, channels: channels,
-                                   windowStart: windowStart, windowEnd: windowEnd)
+            didRefresh = await fetchDispatcharr(
+                server: server,
+                channels: channels,
+                windowStart: windowStart,
+                windowEnd: windowEnd,
+                replaceExisting: replaceExisting
+            )
         case .xtreamCodes:
             // Xtream: still need per-channel fetching with batches
             let initialBatchSize = 40
             let initialChannels = Array(channels.prefix(initialBatchSize))
             let remainingChannels = channels.count > initialBatchSize ? Array(channels.suffix(from: initialBatchSize)) : []
 
-            await fetchXtream(server: server, channels: initialChannels,
-                              windowStart: windowStart, windowEnd: windowEnd)
+            var didReceiveAnyResponse = await fetchXtream(
+                server: server,
+                channels: initialChannels,
+                windowStart: windowStart,
+                windowEnd: windowEnd,
+                replaceExisting: replaceExisting
+            )
 
             // Phase 2: backfill remaining Xtream channels
             if !remainingChannels.isEmpty {
@@ -522,25 +564,39 @@ final class GuideStore: ObservableObject {
                 for batchStart in stride(from: 0, to: remainingChannels.count, by: batchSize) {
                     let batchEnd = min(batchStart + batchSize, remainingChannels.count)
                     let batch = Array(remainingChannels[batchStart..<batchEnd])
-                    await fetchXtream(server: server, channels: batch,
-                                      windowStart: windowStart, windowEnd: windowEnd)
+                    let batchDidRespond = await fetchXtream(
+                        server: server,
+                        channels: batch,
+                        windowStart: windowStart,
+                        windowEnd: windowEnd,
+                        replaceExisting: replaceExisting
+                    )
+                    didReceiveAnyResponse = didReceiveAnyResponse || batchDidRespond
                     await Task.yield()
                 }
             }
+            didRefresh = didReceiveAnyResponse
         case .m3uPlaylist:
-            await fetchXMLTV(server: server, channels: channels,
-                             windowStart: windowStart, windowEnd: windowEnd)
+            didRefresh = await fetchXMLTV(
+                server: server,
+                channels: channels,
+                windowStart: windowStart,
+                windowEnd: windowEnd,
+                replaceExisting: replaceExisting
+            )
         }
 
         // Log final state
         let totalPrograms = programs.values.reduce(0) { $0 + $1.count }
         let channelsWithMultiple = programs.values.filter { $0.count > 1 }.count
         debugLog("📺 GuideStore done: \(totalPrograms) programs across \(programs.count) channels, \(channelsWithMultiple) channels have >1 program")
+        return didRefresh
     }
 
     // MARK: - Dispatcharr
     private func fetchDispatcharr(server: ServerConnection, channels: [ChannelDisplayItem],
-                                   windowStart: Date, windowEnd: Date) async {
+                                   windowStart: Date, windowEnd: Date,
+                                   replaceExisting: Bool = false) async -> Bool {
         // v1.6.22: use Dispatcharr's REST API exclusively. The
         // previous `{baseURL}/output/epg` XMLTV path was attractive
         // because it included `<category>` tags, but it's:
@@ -562,8 +618,6 @@ final class GuideStore: ObservableObject {
         // lazily backfilled per visible cell via /api/epg/programs/<id>/
         // in a future pass if the visual loss matters.
 
-        beginBatch()
-        defer { endBatch() }
         let api = DispatcharrAPI(baseURL: server.effectiveBaseURL,
                                   auth: .apiKey(server.effectiveApiKey),
                                   userAgent: server.effectiveUserAgent,
@@ -577,14 +631,35 @@ final class GuideStore: ObservableObject {
         // the bulk grid omits. We layer the XMLTV merge on top of
         // the REST grid below so categories enrich the same dict.
         let explicitXMLTV = server.dispatcharrXMLTVURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        var didLoadXMLTVOverride = false
         if !explicitXMLTV.isEmpty, let xmltvURL = URL(string: explicitXMLTV) {
             debugLog("📺 [EPG source=dispatcharr-api grid + xmltv-override] server=\(server.name) override=\(xmltvURL.host ?? "?")")
-            await fetchXMLTVFromURL(url: xmltvURL, channels: channels,
-                                     windowStart: windowStart, windowEnd: windowEnd,
-                                     headers: api.streamAuthHeaders)
+            didLoadXMLTVOverride = await fetchXMLTVFromURL(
+                url: xmltvURL,
+                channels: channels,
+                windowStart: windowStart,
+                windowEnd: windowEnd,
+                headers: api.streamAuthHeaders,
+                replaceExisting: replaceExisting
+            )
             // Fall through to bulk grid below: the merge dedupes by
             // (channel, time) so the REST data fills any gaps the
             // override XMLTV missed.
+        }
+
+        let batchBasePrograms: [String: [GuideProgram]]? = {
+            guard replaceExisting else { return nil }
+            guard !didLoadXMLTVOverride else { return programs }
+            return replacingWindowBase(for: channels, windowStart: windowStart, windowEnd: windowEnd)
+        }()
+        beginBatch(basePrograms: batchBasePrograms)
+        var shouldCommitBatch = false
+        defer {
+            if shouldCommitBatch {
+                endBatch()
+            } else {
+                cancelBatch()
+            }
         }
 
         // v1.6.22: fetch the EPGData lookup so we can bridge
@@ -724,6 +799,7 @@ final class GuideStore: ObservableObject {
                                                         uuidToChannelID: uuidToChannelID)
             }
 
+            shouldCommitBatch = true
             return // Grid endpoint succeeded — no need for fallback
         } catch {
             #if DEBUG
@@ -733,7 +809,9 @@ final class GuideStore: ObservableObject {
 
         // Fallback: getCurrentPrograms + getBulkUpcomingPrograms (for older Dispatcharr versions
         // that may not have the /api/epg/grid/ endpoint)
+        var didFetchFallback = false
         if let current = try? await api.getCurrentPrograms() {
+            didFetchFallback = true
             for prog in current {
                 guard let start = prog.startTime?.toDate(),
                       let end = prog.endTime?.toDate(),
@@ -757,6 +835,7 @@ final class GuideStore: ObservableObject {
 
         // Bulk fetch upcoming programs as supplement
         if let allPrograms = try? await api.getBulkUpcomingPrograms(maxPages: 10) {
+            didFetchFallback = true
             for prog in allPrograms {
                 guard let start = prog.startTime?.toDate(),
                       let end = prog.endTime?.toDate(),
@@ -777,35 +856,51 @@ final class GuideStore: ObservableObject {
                 mergeProgram(gp, for: cid)
             }
         }
+
+        shouldCommitBatch = didFetchFallback
+        return didFetchFallback
     }
 
     // MARK: - Xtream Codes
     private func fetchXtream(server: ServerConnection, channels: [ChannelDisplayItem],
-                              windowStart: Date, windowEnd: Date) async {
-        beginBatch()
-        defer { endBatch() }
+                              windowStart: Date, windowEnd: Date,
+                              replaceExisting: Bool = false) async -> Bool {
+        let batchBasePrograms = replaceExisting
+            ? replacingWindowBase(for: channels, windowStart: windowStart, windowEnd: windowEnd)
+            : nil
+        beginBatch(basePrograms: batchBasePrograms)
+        var shouldCommitBatch = false
+        defer {
+            if shouldCommitBatch {
+                endBatch()
+            } else {
+                cancelBatch()
+            }
+        }
         let api = XtreamCodesAPI(baseURL: server.effectiveBaseURL,
                                   username: server.username,
                                   password: server.effectivePassword)
 
         // Fetch with limited concurrency (max 3 concurrent) and 15s timeout per request
-        await withTaskGroup(of: (String, [GuideProgram]).self) { group in
+        let didReceiveAnyResponse = await withTaskGroup(of: (String, [GuideProgram], Bool).self) { group in
             let maxConcurrent = 3
             var launched = 0
+            var didReceiveAnyResponse = false
 
             for ch in channels {
                 if launched >= maxConcurrent {
-                    if let (channelID, progs) = await group.next() {
+                    if let (channelID, progs, didRespond) = await group.next() {
+                        didReceiveAnyResponse = didReceiveAnyResponse || didRespond
                         for p in progs { mergeProgram(p, for: channelID) }
                     }
                 }
                 launched += 1
 
                 group.addTask { [api] in
-                    let progs: [GuideProgram] = await withTaskGroup(of: [GuideProgram].self) { inner in
+                    let result: ([GuideProgram], Bool) = await withTaskGroup(of: ([GuideProgram], Bool).self) { inner in
                         inner.addTask {
                             let response = try? await api.getEPG(streamID: ch.id, limit: 12)
-                            return (response?.epgListings ?? []).compactMap { item in
+                            let progs = (response?.epgListings ?? []).compactMap { item in
                                 guard let start = Self.parseXtreamDate(item.start),
                                       let end = Self.parseXtreamDate(item.end),
                                       end > windowStart && start < windowEnd else { return nil }
@@ -813,23 +908,30 @@ final class GuideStore: ObservableObject {
                                                     description: item.description,
                                                     start: start, end: end, category: "")
                             }
+                            return (progs, response != nil)
                         }
                         inner.addTask {
                             try? await Task.sleep(nanoseconds: 15_000_000_000)
-                            return []
+                            return ([], false)
                         }
-                        let result = await inner.next() ?? []
+                        let result = await inner.next() ?? ([], false)
                         inner.cancelAll()
                         return result
                     }
-                    return (ch.id, progs)
+                    return (ch.id, result.0, result.1)
                 }
             }
 
-            for await (channelID, progs) in group {
+            for await (channelID, progs, didRespond) in group {
+                didReceiveAnyResponse = didReceiveAnyResponse || didRespond
                 for p in progs { mergeProgram(p, for: channelID) }
             }
+
+            return didReceiveAnyResponse
         }
+
+        shouldCommitBatch = didReceiveAnyResponse
+        return didReceiveAnyResponse
     }
 
     // MARK: - Dispatcharr Category Enrichment (v1.6.22)
@@ -901,11 +1003,17 @@ final class GuideStore: ObservableObject {
 
     // MARK: - M3U + XMLTV
     private func fetchXMLTV(server: ServerConnection, channels: [ChannelDisplayItem],
-                             windowStart: Date, windowEnd: Date) async {
+                             windowStart: Date, windowEnd: Date,
+                             replaceExisting: Bool = false) async -> Bool {
         let epgURLStr = server.effectiveEPGURL
-        guard !epgURLStr.isEmpty, let epgURL = URL(string: epgURLStr) else { return }
-        await fetchXMLTVFromURL(url: epgURL, channels: channels,
-                                 windowStart: windowStart, windowEnd: windowEnd)
+        guard !epgURLStr.isEmpty, let epgURL = URL(string: epgURLStr) else { return false }
+        return await fetchXMLTVFromURL(
+            url: epgURL,
+            channels: channels,
+            windowStart: windowStart,
+            windowEnd: windowEnd,
+            replaceExisting: replaceExisting
+        )
     }
 
     /// Core XMLTV fetch/parse path. Accepts a pre-resolved URL so callers
@@ -946,7 +1054,8 @@ final class GuideStore: ObservableObject {
     @discardableResult
     func fetchXMLTVFromURL(url: URL, channels: [ChannelDisplayItem],
                                     windowStart: Date, windowEnd: Date,
-                                    headers: [String: String] = [:]) async -> Bool {
+                                    headers: [String: String] = [:],
+                                    replaceExisting: Bool = false) async -> Bool {
         // In-flight coalescing — see `inFlightXMLTVTask` doc. On
         // cold install two call sites hit this method with the
         // same URL back-to-back; without dedupe we pay the XMLTV
@@ -965,7 +1074,8 @@ final class GuideStore: ObservableObject {
         let fetchTask = Task<Bool, Never> { [self] in
             return await performXMLTVFetch(url: url, channels: channels,
                                            windowStart: windowStart, windowEnd: windowEnd,
-                                           headers: headers)
+                                           headers: headers,
+                                           replaceExisting: replaceExisting)
         }
         inFlightXMLTVTask = (url: url, task: fetchTask)
         let success = await fetchTask.value
@@ -1019,7 +1129,8 @@ final class GuideStore: ObservableObject {
     /// instead of leaving the Guide grid empty.
     private func performXMLTVFetch(url: URL, channels: [ChannelDisplayItem],
                                    windowStart: Date, windowEnd: Date,
-                                   headers: [String: String]) async -> Bool {
+                                   headers: [String: String],
+                                   replaceExisting: Bool) async -> Bool {
         // v1.6.22: log the actual error instead of swallowing it via
         // `try?`. The previous "XMLTV fetch/parse failed for <host>"
         // line told us nothing about WHY (auth? timeout? parse error?),
@@ -1073,7 +1184,9 @@ final class GuideStore: ObservableObject {
         // task below mutates its own local copy; the first write
         // triggers the deep copy, off-main. `self.programs` itself
         // stays untouched until the final assignment.
-        let snapshot = programs
+        let snapshot = replaceExisting
+            ? replacingWindowBase(for: channels, windowStart: windowStart, windowEnd: windowEnd)
+            : programs
 
         // Run the 98k-iteration merge off the MainActor.
         let result = await Task.detached(priority: .userInitiated) { () -> XMLTVMergeResult in

--- a/Features/LiveTV/EPGGuideView.swift
+++ b/Features/LiveTV/EPGGuideView.swift
@@ -96,10 +96,19 @@ final class GuideStore: ObservableObject {
     /// torture playlist; running them serially doubles the cold-
     /// install wait. When the second caller arrives while the
     /// first is still parsing, it awaits the first's `.value`
-    /// instead of starting a duplicate download. Different URLs
-    /// (e.g. an explicit per-server override vs. the derived
-    /// `/output/epg`) don't coalesce — only exact URL matches.
-    private var inFlightXMLTVTask: (url: URL, task: Task<Bool, Never>)? = nil
+    /// instead of starting a duplicate download. Coalescing also
+    /// has to respect the non-URL semantics introduced later:
+    /// `replaceExisting` changes whether the fetched window
+    /// replaces the old slice, and `categoryServerID` scopes where
+    /// the resulting tint metadata is published. Callers only join
+    /// when all three match.
+    private struct InFlightXMLTVKey: Equatable {
+        let url: URL
+        let categoryServerID: String
+        let replaceExisting: Bool
+    }
+
+    private var inFlightXMLTVTask: (key: InFlightXMLTVKey, task: Task<Bool, Never>)? = nil
 
     /// Signature of the last seedEPGCache run — "serverID|channelCount|programCount".
     /// Warm relaunch fires `seedEPGCache` three times with identical
@@ -803,7 +812,7 @@ final class GuideStore: ObservableObject {
             }
 
             shouldCommitBatch = true
-            return // Grid endpoint succeeded — no need for fallback
+            return true // Grid endpoint succeeded — no need for fallback
         } catch {
             #if DEBUG
             debugLog("📺 Dispatcharr: EPG grid failed (\(error)), falling back to current+bulk approach")
@@ -860,8 +869,9 @@ final class GuideStore: ObservableObject {
             }
         }
 
-        shouldCommitBatch = didFetchFallback
-        return didFetchFallback
+        let didRefresh = didLoadXMLTVOverride || didFetchFallback
+        shouldCommitBatch = didRefresh
+        return didRefresh
     }
 
     // MARK: - Xtream Codes
@@ -1062,12 +1072,17 @@ final class GuideStore: ObservableObject {
                                     headers: [String: String] = [:],
                                     categoryServerID: String,
                                     replaceExisting: Bool = false) async -> Bool {
+        let inFlightKey = InFlightXMLTVKey(
+            url: url,
+            categoryServerID: categoryServerID,
+            replaceExisting: replaceExisting
+        )
         // In-flight coalescing — see `inFlightXMLTVTask` doc. On
         // cold install two call sites hit this method with the
         // same URL back-to-back; without dedupe we pay the XMLTV
         // download + parse twice (~3 min each on the 98k-program
         // torture playlist).
-        if let inFlight = inFlightXMLTVTask, inFlight.url == url {
+        if let inFlight = inFlightXMLTVTask, inFlight.key == inFlightKey {
             debugLog("📺 GuideStore.fetchXMLTVFromURL: joining in-flight parse (url=\(url.host ?? "?"))")
             return await inFlight.task.value
         }
@@ -1084,12 +1099,13 @@ final class GuideStore: ObservableObject {
                                            categoryServerID: categoryServerID,
                                            replaceExisting: replaceExisting)
         }
-        inFlightXMLTVTask = (url: url, task: fetchTask)
+        inFlightXMLTVTask = (key: inFlightKey, task: fetchTask)
         let success = await fetchTask.value
         // Only clear if we're still the registered in-flight task
-        // for this URL. A different URL starting later would have
-        // overwritten the entry; don't stomp it.
-        if inFlightXMLTVTask?.url == url {
+        // for this full request shape. A different XMLTV request
+        // starting later would have overwritten the entry; don't
+        // stomp it.
+        if inFlightXMLTVTask?.key == inFlightKey {
             inFlightXMLTVTask = nil
         }
         return success

--- a/Features/LiveTV/EPGGuideView.swift
+++ b/Features/LiveTV/EPGGuideView.swift
@@ -622,6 +622,7 @@ final class GuideStore: ObservableObject {
                                   auth: .apiKey(server.effectiveApiKey),
                                   userAgent: server.effectiveUserAgent,
                                   authMode: server.dispatcharrHeaderMode)
+        let categoryServerID = server.id.uuidString
         debugLog("📺 [EPG source=dispatcharr-api grid] server=\(server.name)")
 
         // v1.6.22: honor user-provided XMLTV override URL if set.
@@ -640,6 +641,7 @@ final class GuideStore: ObservableObject {
                 windowStart: windowStart,
                 windowEnd: windowEnd,
                 headers: api.streamAuthHeaders,
+                categoryServerID: categoryServerID,
                 replaceExisting: replaceExisting
             )
             // Fall through to bulk grid below: the merge dedupes by
@@ -796,7 +798,8 @@ final class GuideStore: ObservableObject {
                 await self.enrichDispatcharrCategories(gridPrograms: gridPrograms,
                                                         api: api,
                                                         tvgIDToChannelID: tvgIDToChannelID,
-                                                        uuidToChannelID: uuidToChannelID)
+                                                        uuidToChannelID: uuidToChannelID,
+                                                        serverID: categoryServerID)
             }
 
             shouldCommitBatch = true
@@ -948,7 +951,8 @@ final class GuideStore: ObservableObject {
         gridPrograms: [DispatcharrCurrentProgram],
         api: DispatcharrAPI,
         tvgIDToChannelID: [String: String],
-        uuidToChannelID: [String: String]
+        uuidToChannelID: [String: String],
+        serverID: String
     ) async {
         let now = Date()
         var currentByChannelID: [String: Int] = [:]
@@ -998,7 +1002,7 @@ final class GuideStore: ObservableObject {
         self.programs = updated
 
         // Apply to Live-TV channel-card stripe.
-        ChannelStore.shared.applyXMLTVCategories(byChannel)
+        ChannelStore.shared.applyXMLTVCategories(byChannel, serverID: serverID)
     }
 
     // MARK: - M3U + XMLTV
@@ -1012,6 +1016,7 @@ final class GuideStore: ObservableObject {
             channels: channels,
             windowStart: windowStart,
             windowEnd: windowEnd,
+            categoryServerID: server.id.uuidString,
             replaceExisting: replaceExisting
         )
     }
@@ -1055,6 +1060,7 @@ final class GuideStore: ObservableObject {
     func fetchXMLTVFromURL(url: URL, channels: [ChannelDisplayItem],
                                     windowStart: Date, windowEnd: Date,
                                     headers: [String: String] = [:],
+                                    categoryServerID: String,
                                     replaceExisting: Bool = false) async -> Bool {
         // In-flight coalescing — see `inFlightXMLTVTask` doc. On
         // cold install two call sites hit this method with the
@@ -1075,6 +1081,7 @@ final class GuideStore: ObservableObject {
             return await performXMLTVFetch(url: url, channels: channels,
                                            windowStart: windowStart, windowEnd: windowEnd,
                                            headers: headers,
+                                           categoryServerID: categoryServerID,
                                            replaceExisting: replaceExisting)
         }
         inFlightXMLTVTask = (url: url, task: fetchTask)
@@ -1130,6 +1137,7 @@ final class GuideStore: ObservableObject {
     private func performXMLTVFetch(url: URL, channels: [ChannelDisplayItem],
                                    windowStart: Date, windowEnd: Date,
                                    headers: [String: String],
+                                   categoryServerID: String,
                                    replaceExisting: Bool) async -> Bool {
         // v1.6.22: log the actual error instead of swallowing it via
         // `try?`. The previous "XMLTV fetch/parse failed for <host>"
@@ -1252,7 +1260,7 @@ final class GuideStore: ObservableObject {
         debugLog("📺 XMLTV \(hostLabel): \(result.matched) programs matched, \(result.missed) skipped (no channel)")
         // Back-fill ChannelStore so Tint Channel Cards reflects
         // the XMLTV categories on every channel row.
-        ChannelStore.shared.applyXMLTVCategories(result.currentCategoriesByChannelID)
+        ChannelStore.shared.applyXMLTVCategories(result.currentCategoriesByChannelID, serverID: categoryServerID)
         return true
     }
 

--- a/Features/Settings/SettingsView.swift
+++ b/Features/Settings/SettingsView.swift
@@ -1768,6 +1768,9 @@ struct ServerDetailView: View {
         //      different server's payload. For non-active purges we
         //      just clear the cache and let the next activation
         //      refetch normally.
+        //   3. Persists the freshly-fetched guide back to SwiftData
+        //      so the next launch sees the rebuilt cache instead of
+        //      the just-purged empty store.
         .alert("Refresh EPG Data?", isPresented: $showPurgeConfirmation) {
             Button("Cancel", role: .cancel) {}
             Button("Refresh", role: .destructive) {
@@ -1780,6 +1783,7 @@ struct ServerDetailView: View {
                     )
                     if server.isActive {
                         await ChannelStore.shared.forceRefresh(servers: Array(servers))
+                        GuideStore.shared.saveToCache(modelContext: modelContext, serverID: server.id.uuidString)
                     }
                     isPurgingEPG = false
                 }

--- a/Features/Settings/SettingsView.swift
+++ b/Features/Settings/SettingsView.swift
@@ -1768,9 +1768,6 @@ struct ServerDetailView: View {
         //      different server's payload. For non-active purges we
         //      just clear the cache and let the next activation
         //      refetch normally.
-        //   3. Persists the freshly-fetched guide back to SwiftData
-        //      so the next launch sees the rebuilt cache instead of
-        //      the just-purged empty store.
         .alert("Refresh EPG Data?", isPresented: $showPurgeConfirmation) {
             Button("Cancel", role: .cancel) {}
             Button("Refresh", role: .destructive) {
@@ -1782,8 +1779,7 @@ struct ServerDetailView: View {
                         modelContext: modelContext
                     )
                     if server.isActive {
-                        await ChannelStore.shared.forceRefresh(servers: Array(servers))
-                        GuideStore.shared.saveToCache(modelContext: modelContext, serverID: server.id.uuidString)
+                        await ChannelStore.shared.forceRefresh(servers: Array(servers), modelContext: modelContext)
                     }
                     isPurgingEPG = false
                 }
@@ -3890,4 +3886,3 @@ extension View {
     }
 }
 #endif
-


### PR DESCRIPTION
This is a grab-bag of EPG fixes for a few bits of weirdness that were all related.

- manual refresh and cache-purge flows now rebuild guide data right away instead of only getting back to normal after a relaunch
  
- pull-to-refresh, retry, and Settings-triggered EPG refreshes now write the rebuilt guide back to SwiftData too, not just the in-memory store

- refreshed guide windows replace the old slice instead of just piling new rows on top, so stale programs do not hang around
- if a refresh source fails, we keep the last good in-memory guide instead of punching a hole in it

- channel category tint cache is now scoped per server, and async XMLTV / Dispatcharr category updates carry server identity so one playlist cannot paint another by accident