### PR TITLE
perf(network): reuse fetch sessions and preserve NW fallback timeouts

### DIFF
--- a/Networking/HTTPRouter.swift
+++ b/Networking/HTTPRouter.swift
@@ -47,6 +47,9 @@ import Foundation
 /// rules without per-call awareness.
 enum HTTPRouter {
 
+    private static let defaultRequestTimeout = URLSessionConfiguration.default.timeoutIntervalForRequest
+    private static let defaultResourceTimeout = URLSessionConfiguration.default.timeoutIntervalForResource
+
     // MARK: - Public API
 
     static func data(from url: URL,
@@ -54,7 +57,8 @@ enum HTTPRouter {
         // Hard route: HSTS-preloaded TLD plain HTTP — URLSession will
         // always refuse, so go straight to NWConnection.
         if shouldUseNWConnection(for: url) {
-            return try await NWHTTPClient.data(from: url)
+            return try await NWHTTPClient.data(from: url,
+                                               timeout: effectiveNWTimeout(using: session))
         }
         // Soft route: URLSession first; if it fails with a transport
         // error that NWConnection might handle differently, try
@@ -69,7 +73,8 @@ enum HTTPRouter {
         } catch let error as NSError where shouldFallbackToNWConnection(error: error) {
             debugLog("HTTPRouter: URLSession failed for \(url.absoluteString) (code=\(error.code) \(error.localizedDescription)) → NWConnection fallback")
             do {
-                return try await NWHTTPClient.data(from: url)
+                return try await NWHTTPClient.data(from: url,
+                                                   timeout: effectiveNWTimeout(using: session))
             } catch {
                 // NWConnection ALSO failed. Throw the URLSession error;
                 // it's typically more localized / actionable.
@@ -82,7 +87,8 @@ enum HTTPRouter {
     static func data(for request: URLRequest,
                      using session: URLSession = .shared) async throws -> (Data, URLResponse) {
         if let url = request.url, shouldUseNWConnection(for: url) {
-            return try await NWHTTPClient.data(for: request)
+            return try await NWHTTPClient.data(for: request,
+                                               timeout: effectiveNWTimeout(for: request, using: session))
         }
         do {
             return try await session.data(for: request)
@@ -90,12 +96,42 @@ enum HTTPRouter {
             let urlStr = request.url?.absoluteString ?? "<unknown>"
             debugLog("HTTPRouter: URLSession failed for \(urlStr) (code=\(error.code) \(error.localizedDescription)) → NWConnection fallback")
             do {
-                return try await NWHTTPClient.data(for: request)
+                return try await NWHTTPClient.data(for: request,
+                                                   timeout: effectiveNWTimeout(for: request, using: session))
             } catch {
                 debugLog("HTTPRouter: NWConnection fallback ALSO failed: \(error)")
                 throw error
             }
         }
+    }
+
+    private static func effectiveNWTimeout(using session: URLSession) -> TimeInterval {
+        effectiveNWTimeout(for: nil, using: session)
+    }
+
+    private static func effectiveNWTimeout(for request: URLRequest?,
+                                           using session: URLSession) -> TimeInterval {
+        var candidates: [TimeInterval] = []
+
+        if let request,
+           request.timeoutInterval > 0,
+           request.timeoutInterval != defaultRequestTimeout {
+            candidates.append(request.timeoutInterval)
+        }
+
+        let sessionRequestTimeout = session.configuration.timeoutIntervalForRequest
+        if sessionRequestTimeout > 0,
+           sessionRequestTimeout != defaultRequestTimeout {
+            candidates.append(sessionRequestTimeout)
+        }
+
+        let sessionResourceTimeout = session.configuration.timeoutIntervalForResource
+        if sessionResourceTimeout > 0,
+           sessionResourceTimeout != defaultResourceTimeout {
+            candidates.append(sessionResourceTimeout)
+        }
+
+        return candidates.max() ?? NWHTTPClient.defaultTimeout
     }
 
     // MARK: - Routing decision

--- a/Networking/PlaylistParsers.swift
+++ b/Networking/PlaylistParsers.swift
@@ -117,6 +117,12 @@ struct ParsedEPGProgram {
 // MARK: - XMLTV Parser (class required for NSObject/XMLParserDelegate)
 final class XMLTVParser: NSObject, XMLParserDelegate {
 
+    private static let session: URLSession = {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 60
+        return URLSession(configuration: config)
+    }()
+
     private var programmes: [ParsedEPGProgram] = []
     private var currentChannelID = ""
     private var currentTitle = ""
@@ -168,9 +174,6 @@ final class XMLTVParser: NSObject, XMLParserDelegate {
     /// gap. Empty dict for M3U / public XMLTV URLs preserves the
     /// previous behaviour.
     static func fetchAndParse(url: URL, headers: [String: String] = [:]) async throws -> [ParsedEPGProgram] {
-        let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = 60
-        let session = URLSession(configuration: config)
         var request = URLRequest(url: url)
         headers.forEach { request.setValue($1, forHTTPHeaderField: $0) }
         let (data, response) = try await session.data(for: request)

--- a/Networking/StreamingAPIs.swift
+++ b/Networking/StreamingAPIs.swift
@@ -100,6 +100,12 @@ struct XtreamCodesAPI {
         config.timeoutIntervalForResource = 300
         return URLSession(configuration: config)
     }()
+    private static let largeLibrarySession: URLSession = {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 30
+        config.timeoutIntervalForResource = 180
+        return URLSession(configuration: config)
+    }()
     private var session: URLSession { Self.session }
 
     /// Reusable decoder. v1.6.22: previously every decode call
@@ -147,13 +153,8 @@ struct XtreamCodesAPI {
         var params: [String: String] = ["action": "get_vod_streams"]
         if let id = categoryID { params["category_id"] = id }
         let url = try buildURL(path: "/player_api.php", params: params)
-        // VOD libraries can be very large — use a dedicated session with generous timeouts
-        let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = 30
-        config.timeoutIntervalForResource = 180
-        let vodSession = URLSession(configuration: config)
         // v1.6.10: HTTPRouter.data so HSTS-preloaded TLD HTTP URLs work.
-        let (data, response) = try await HTTPRouter.data(from: url, using: vodSession)
+        let (data, response) = try await HTTPRouter.data(from: url, using: Self.largeLibrarySession)
         try validate(response: response)
         // Some panels return false/null/object for empty or unavailable VOD — treat as empty
         if let items = try? decode([XtreamVODItem].self, from: data) { return items }
@@ -184,13 +185,8 @@ struct XtreamCodesAPI {
         var params: [String: String] = ["action": "get_series"]
         if let id = categoryID { params["category_id"] = id }
         let url = try buildURL(path: "/player_api.php", params: params)
-        // Series libraries can be very large — use a dedicated session with generous timeouts
-        let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = 30
-        config.timeoutIntervalForResource = 180
-        let seriesSession = URLSession(configuration: config)
         // v1.6.10: HTTPRouter.data so HSTS-preloaded TLD HTTP URLs work.
-        let (data, response) = try await HTTPRouter.data(from: url, using: seriesSession)
+        let (data, response) = try await HTTPRouter.data(from: url, using: Self.largeLibrarySession)
         try validate(response: response)
         // Some panels return false/null/object for empty or unavailable series — treat as empty
         if let items = try? decode([XtreamSeriesItem].self, from: data) { return items }
@@ -705,6 +701,14 @@ struct DispatcharrAPI {
         // through the semaphore.
         config.timeoutIntervalForRequest = 60
         config.timeoutIntervalForResource = 600
+        return URLSession(configuration: config,
+                          delegate: redirectDelegate,
+                          delegateQueue: nil)
+    }()
+    private static let bulkEPGSession: URLSession = {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 15
+        config.timeoutIntervalForResource = 60
         return URLSession(configuration: config,
                           delegate: redirectDelegate,
                           delegateQueue: nil)
@@ -1506,11 +1510,6 @@ struct DispatcharrAPI {
     // Fetches ALL programs from /api/epg/programs/ in a time window using large pages.
     // This replaces 40+ per-channel requests with ~3–5 paginated requests.
     func getBulkUpcomingPrograms(maxPages: Int = 10) async throws -> [DispatcharrCurrentProgram] {
-        let epgConfig = URLSessionConfiguration.default
-        epgConfig.timeoutIntervalForRequest = 15
-        epgConfig.timeoutIntervalForResource = 60
-        let epgSession = URLSession(configuration: epgConfig)
-
         // Fetch all programs with a large page size — no per-channel filter.
         // The server returns programs sorted by start_time by default.
         var allItems: [DispatcharrCurrentProgram] = []
@@ -1522,7 +1521,7 @@ struct DispatcharrAPI {
             var request = URLRequest(url: url)
             headers.forEach { request.setValue($1, forHTTPHeaderField: $0) }
             // v1.6.10: HTTPRouter.data so HSTS-preloaded TLD HTTP URLs work.
-            let (data, response) = try await HTTPRouter.data(for: request, using: epgSession)
+            let (data, response) = try await HTTPRouter.data(for: request, using: Self.bulkEPGSession)
             guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else { break }
 
             if let list = try? Self.jsonDecoder.decode([DispatcharrCurrentProgram].self, from: data) {
@@ -3626,4 +3625,3 @@ struct DispatcharrChannelGroup: Decodable, Identifiable {
         case channelCount = "channel_count"
     }
 }
-

--- a/Networking/XtreamSeriesAPI.swift
+++ b/Networking/XtreamSeriesAPI.swift
@@ -25,7 +25,7 @@ extension XtreamCodesAPI {
         ]
         guard let url = components.url else { throw APIError.invalidURL }
 
-        let (data, response) = try await XtreamSeriesInfoSession.session.data(from: url)
+        let (data, response) = try await HTTPRouter.data(from: url, using: XtreamSeriesInfoSession.session)
 
         guard let http = response as? HTTPURLResponse else { throw APIError.invalidResponse }
         switch http.statusCode {

--- a/Networking/XtreamSeriesAPI.swift
+++ b/Networking/XtreamSeriesAPI.swift
@@ -3,6 +3,14 @@ import Foundation
 // MARK: - Xtream Codes Series Detail Extension
 // Adds getSeriesInfo() and associated response models.
 
+private enum XtreamSeriesInfoSession {
+    static let session: URLSession = {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 20
+        return URLSession(configuration: config)
+    }()
+}
+
 extension XtreamCodesAPI {
     /// Fetch full series detail including seasons and episodes.
     func getSeriesInfo(seriesID: String) async throws -> XtreamSeriesDetail {
@@ -17,10 +25,7 @@ extension XtreamCodesAPI {
         ]
         guard let url = components.url else { throw APIError.invalidURL }
 
-        let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = 20
-        let sess = URLSession(configuration: config)
-        let (data, response) = try await sess.data(from: url)
+        let (data, response) = try await XtreamSeriesInfoSession.session.data(from: url)
 
         guard let http = response as? HTTPURLResponse else { throw APIError.invalidResponse }
         switch http.statusCode {


### PR DESCRIPTION
Reuse long-lived URLSession instances for large Xtream, Dispatcharr, XMLTV, and Xtream series-detail fetches instead of creating ad hoc sessions per call.

Preserve request/session timeout intent when HTTPRouter falls back to NWHTTPClient so large HSTS-bypass requests do not silently drop back to the transport default timeout.